### PR TITLE
Add browser field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "description": "A set of helper classes for working with strings, objects, etc.",
   "module": "src/index.js",
-  "main": "dist/index.js",
+  "browser": "dist/index.js",
   "files": [
     "src",
     "dist"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1",
   "description": "A set of helper classes for working with strings, objects, etc.",
   "module": "src/index.js",
+  "main": "dist/index.js",
   "browser": "dist/index.js",
   "files": [
     "src",


### PR DESCRIPTION
To be able to access the es5 build via `import { XYUtil } from '@terrestris/base-util'` browser field needed to be added to package.json.