### PR TITLE
Downgrade query string version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "lodash": "4.17.11",
     "loglevel": "1.6.1",
-    "query-string": "6.2.0",
+    "query-string": "5.1.1",
     "url-parse": "1.4.4",
     "validator": "10.9.0"
   },
@@ -59,5 +59,10 @@
     "np": "3.0.4",
     "rimraf": "2.6.2",
     "whatwg-fetch": "3.0.0"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "query-string"
+    ]
   }
 }


### PR DESCRIPTION
In order to support older browsers (like IE11), `query-string` should be downgraded to version 5.1.1 