### PR TITLE
Replace deprecated jest config with suggested alternative

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,9 @@ module.exports = {
     '^.+\\.jsx?$': '<rootDir>/node_modules/babel-jest',
     '^.+\\.ts?$': 'ts-jest'
   },
-  setupTestFrameworkScriptFile: '<rootDir>/jest/setup.js',
+  setupFilesAfterEnv: [
+    '<rootDir>/jest/setup.js'
+  ],
   // setupFiles: [
   //   '<rootDir>/jest/__mocks__/shim.js',
   //   '<rootDir>/jest/setup.js'


### PR DESCRIPTION
This removes the following `jest` deprecation warning when running `npm test`:

```
● Deprecation Warning:

  Option "setupTestFrameworkScriptFile" was replaced by configuration "setupFilesAfterEnv", which supports multiple paths.

  Please update your configuration.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```

Please review.