### PR TITLE
Remove deprecated @types/query-string package

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,0 +1,1 @@
+declare module 'query-string';

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/jest": "24.0.11",
     "@types/lodash": "4.14.122",
     "@types/loglevel": "1.5.4",
-    "@types/query-string": "6.2.0",
     "@types/url-parse": "1.4.3",
     "@types/validator": "10.9.0",
     "coveralls": "3.0.3",


### PR DESCRIPTION
`@types/query-string` package has been deprecated and will be removed now.
Additionally added a missing declaration for `query-string` package instead.

Please review @terrestris/devs 