### PR TITLE
Add util to read csrf cookie

### DIFF
--- a/src/CsrfUtil/CsrfUtil.spec.ts
+++ b/src/CsrfUtil/CsrfUtil.spec.ts
@@ -5,6 +5,7 @@ import template from 'lodash/template';
 import CsrfUtil from './CsrfUtil';
 import Logger from '../Logger';
 
+const csrfCookieName = 'XSRF-TOKEN';
 const tokenValue = 'my-csrf-token-value';
 const headerName = 'my-csrf-header-name';
 const paramName = 'my-csrf-param-name';
@@ -33,6 +34,13 @@ describe('CsrfUtil', () => {
 
   describe('Static methods', () => {
     beforeEach(() => {
+      // set csrf cookie
+      let expires = "";
+      const date = new Date();
+      date.setTime(date.getTime() + (24*60*60*1000));
+      expires = "; expires=" + date.toUTCString();
+      document.cookie = csrfCookieName + "=" + (tokenValue || "")  + expires + "; path=/";
+
       // add custom CSRF headers
       specs.forEach((spec) => {
         let tagElement = document.createElement(spec.tag);
@@ -43,6 +51,8 @@ describe('CsrfUtil', () => {
     });
 
     afterEach(() => {
+      // remove cookie
+      document.cookie = csrfCookieName + '=; Max-Age=-99999999;';
       // remove custom CSRF headers
       specs.forEach((spec) => {
         let compiledSelector = template('meta[name="<%= metaTagName %>"]');
@@ -53,6 +63,11 @@ describe('CsrfUtil', () => {
 
     it('getCsrfValue', () => {
       let result = CsrfUtil.getCsrfValue();
+      expect(result).toBe(tokenValue);
+    });
+
+    it('getCsrfValueFromCookie', () => {
+      let result = CsrfUtil.getCsrfValueFromCookie();
       expect(result).toBe(tokenValue);
     });
 

--- a/src/CsrfUtil/CsrfUtil.ts
+++ b/src/CsrfUtil/CsrfUtil.ts
@@ -57,6 +57,22 @@ class CsrfUtil {
   }
 
   /**
+   * Get the CSRF token value from the `XSRF-TOKEN` cookie. Alternative to
+   * the `getCsrfValue` method.
+   *
+   * When using Spring Security, a `CookieCsrfTokenRepository` has to be
+   * configured to persist the CSRF token.
+   *
+   * @return {string} - the key value, e.g. "741a3b1-221f-4d1d-..." or an
+   *     empty string if the `XSRF_TOKEN` cookie cannot be found.
+   */
+  static getCsrfValueFromCookie(): string {
+    const csrfCookie = document.cookie.replace(
+      /(?:(?:^|.*;\s*)XSRF-TOKEN\s*\=\s*([^;]*).*$)|^.*$/, '$1');
+    return csrfCookie || '';
+  }
+
+  /**
    * Get the CSRF token key. This can be used if you want to send CSRF
    * tokens as header. If you want to send it using a form parameter, use
    * the method #getParamName instead.


### PR DESCRIPTION
Adds a method to obtain the csrf token from the `XSRF-TOKEN` cookie

This is needed when using Spring Security's CookieCsrfTokenRepository , see https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/csrf.html#csrf-cookie for more info

@terrestris/devs Please review