### PR TITLE
`Logger.ts` to use default import

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,4 +1,4 @@
-import * as log from 'loglevel';
+import log from 'loglevel';
 
 const logger = log.getLogger('app-logger');
 


### PR DESCRIPTION
`Logger.ts` to use default import for `logLevel` package. No longer using wildcard (`*`) import.