### PR TITLE
Add some HttpUtil tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6031,6 +6031,15 @@
         }
       }
     },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -8552,6 +8561,16 @@
         }
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "25.2.6",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
@@ -10748,6 +10767,12 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11677,6 +11702,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
       "dev": true
     },
     "prompts": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "coveralls": "^3.0.9",
     "gh-pages": "^3.1.0",
     "jest": "^25.2.3",
+    "jest-fetch-mock": "^3.0.3",
     "np": "^6.2.0",
     "rimraf": "^3.0.0",
     "ts-jest": "^25.2.1",

--- a/src/HttpUtil/HttpUtil.spec.ts
+++ b/src/HttpUtil/HttpUtil.spec.ts
@@ -1,8 +1,15 @@
 /*eslint-env jest*/
+import { enableFetchMocks } from 'jest-fetch-mock';
+enableFetchMocks();
 
 import HttpUtil from './HttpUtil';
 
 describe('HttpUtil', () => {
+  beforeEach(() => {
+    // @ts-expect-error
+    fetch.resetMocks();
+  });
+
   it('is defined', () => {
     expect(HttpUtil).not.toBe(undefined);
   });
@@ -15,12 +22,135 @@ describe('HttpUtil', () => {
 
     it('returns valid promise', () => {
       const params = {
-        url: 'https://test/test',
-        asForm: false
+        url: 'https://test/test'
       };
       const result = HttpUtil.post(params);
       expect(result).toBeInstanceOf(Promise);
     });
+
+    it('fetches the given URL', async () => {
+      const params = {
+        url: 'https://test/test'
+      };
+      await HttpUtil.post(params);
+      // @ts-expect-error
+      expect(fetch.mock.calls.length).toEqual(1);
+      // @ts-expect-error
+      expect(fetch.mock.calls[0][0]).toEqual('https://test/test');
+    });
+
+    it('sends the given parameters', async () => {
+      const params = {
+        url: 'https://test/test',
+        params: {
+          humpty: 'dumpty'
+        },
+        asForm: false
+      };
+      await HttpUtil.post(params);
+      // @ts-expect-error
+      expect(fetch.mock.calls.length).toEqual(1);
+      // @ts-expect-error
+      const fetchOpts = fetch.mock.calls[0][1];
+      expect(fetchOpts.body).toEqual(JSON.stringify(params.params));
+    });
+
+    it('sends the given additional headers', async () => {
+      const params = {
+        url: 'https://test/test',
+        additionalHeaders: {
+          'x-foo': 'bar'
+        }
+      };
+      await HttpUtil.post(params);
+      // @ts-expect-error
+      expect(fetch.mock.calls.length).toEqual(1);
+      // @ts-expect-error
+      const headers = fetch.mock.calls[0][1].headers;
+      expect(headers.get('x-foo')).toEqual('bar');
+    });
+
+    it('sends the ContentType headers if asForm = true (default)', async () => {
+      const params = {
+        url: 'https://test/test'
+      };
+      await HttpUtil.post(params);
+      // @ts-expect-error
+      expect(fetch.mock.calls.length).toEqual(1);
+      // @ts-expect-error
+      const headers = fetch.mock.calls[0][1].headers;
+      expect(headers.get('Content-Type')).toEqual('application/x-www-form-urlencoded');
+    });
+
+    it('doesn\'t send the ContentType headers if asForm = false', async () => {
+      const params = {
+        url: 'https://test/test',
+        asForm: false
+      };
+      await HttpUtil.post(params);
+      // @ts-expect-error
+      expect(fetch.mock.calls.length).toEqual(1);
+      // @ts-expect-error
+      const headers = fetch.mock.calls[0][1].headers;
+      expect(headers.get('Content-Type')).toEqual(null);
+    });
+
+    it('fetch options can be set', async () => {
+      const params = {
+        url: 'https://test/test',
+        additionalFetchOptions: {
+          cache: 'no-cache'
+        }
+      };
+      await HttpUtil.post(params);
+      // @ts-expect-error
+      expect(fetch.mock.calls.length).toEqual(1);
+      // @ts-expect-error
+      const gotCache = fetch.mock.calls[0][1].cache;
+      expect(gotCache).toEqual('no-cache');
+    });
+
+    it('fetches with same-origin credentials (default)', async () => {
+      const params = {
+        url: 'https://test/test'
+      };
+      await HttpUtil.post(params);
+      // @ts-expect-error
+      expect(fetch.mock.calls.length).toEqual(1);
+      // @ts-expect-error
+      const gotCreds = fetch.mock.calls[0][1].credentials;
+      expect(gotCreds).toEqual('same-origin');
+    });
+
+    it('fetching with same-origin credentials can be turned off', async () => {
+      const params = {
+        url: 'https://test/test',
+        sameOriginCredentials: false
+      };
+      await HttpUtil.post(params);
+      // @ts-expect-error
+      expect(fetch.mock.calls.length).toEqual(1);
+      // @ts-expect-error
+      const gotCreds = fetch.mock.calls[0][1].credentials;
+      expect(gotCreds).toEqual(undefined);
+    });
+
+    it('can fetch with params (json)', async () => {
+      const params = {
+        url: 'https://test/test',
+        params: {
+          humpty: 'dumpty'
+        },
+        asForm: false
+      };
+      await HttpUtil.post(params);
+      // @ts-expect-error
+      expect(fetch.mock.calls.length).toEqual(1);
+      // @ts-expect-error
+      const gotBody = fetch.mock.calls[0][1].body;
+      expect(JSON.parse(gotBody)).toEqual({ humpty: 'dumpty' });
+    });
+
   });
 
 });


### PR DESCRIPTION
This suggests to add some tests for the `HttpUtil` class by utilizing the [`jest-fetch-mock` package](https://www.npmjs.com/package/jest-fetch-mock). I aimed for 100% coverage, but failed because of

* I don't know how to test for the `catch` case, even though [it should be possible](https://www.npmjs.com/package/jest-fetch-mock#mocking-a-failed-fetch)
* I did not manage to have the test submit `params` as when `asForm` is `true`, very strange indeed

Additionally, I had to add several `// @ts-expect-error` lines, as TypeScript would not know about the properties added by mocking the `fetch`-API. There should be ways around this, but I failed to configure this appropriately; these [documentation lines of `jest-fetch-mock`](https://www.npmjs.com/package/jest-fetch-mock#typescript-importing) might be helpful.

Improvements there are more than welcome.

Nonetheless I think this is an improvement.

Please review.
