### PR TITLE
Update several dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1454,9 +1454,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz",
-          "integrity": "sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==",
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
           "dev": true
         }
       }
@@ -3042,49 +3042,54 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz",
-          "integrity": "sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==",
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
           "dev": true
         }
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.17.tgz",
-      "integrity": "sha512-mwaVNcXV+l6qJOuRhpdTEj8sT/Z0owAVWf9QujTZ0d2ye9X/K+MTOTSizcgKOj18PGnTc/7g1I4+cIUjsKhBcw==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.13.12.tgz",
+      "integrity": "sha512-jcEI2UqIcpCqB5U5DRxIl0tQEProI2gcu+g8VTIqxLO5Iidojb4d77q+fwGseCvd8af/lJ9masp4QWzBXFE2xA==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.12.13",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-module-imports": "^7.13.12",
+        "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-jsx": "^7.12.13",
-        "@babel/types": "^7.12.17"
+        "@babel/types": "^7.13.12"
       },
       "dependencies": {
         "@babel/helper-module-imports": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-          "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+          "version": "7.13.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+          "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.12.13"
+            "@babel/types": "^7.13.12"
           }
         },
         "@babel/helper-plugin-utils": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz",
-          "integrity": "sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==",
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+          "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
           "dev": true
         },
         "@babel/types": {
-          "version": "7.12.17",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.17.tgz",
-          "integrity": "sha512-tNMDjcv/4DIcHxErTgwB9q2ZcYyN0sUfgGKUK/mm1FJK7Wz+KstoEekxrl/tBiNDgLK1HGi+sppj1An/1DR4fQ==",
+          "version": "7.14.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.1.tgz",
+          "integrity": "sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
+            "@babel/helper-validator-identifier": "^7.14.0",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -3399,22 +3404,23 @@
       }
     },
     "@babel/preset-react": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.13.tgz",
-      "integrity": "sha512-TYM0V9z6Abb6dj1K7i5NrEhA13oS5ujUYQYDfqIBXYHOc2c2VkFgc+q9kyssIyUfy4/hEwqrgSlJ/Qgv8zJLsA==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.13.13.tgz",
+      "integrity": "sha512-gx+tDLIE06sRjKJkVtpZ/t3mzCDOnPG+ggHZG9lffUbX8+wC739x20YQc9V35Do6ZAxaUc/HhVHIiOzz5MvDmA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-validator-option": "^7.12.17",
         "@babel/plugin-transform-react-display-name": "^7.12.13",
-        "@babel/plugin-transform-react-jsx": "^7.12.13",
-        "@babel/plugin-transform-react-jsx-development": "^7.12.12",
+        "@babel/plugin-transform-react-jsx": "^7.13.12",
+        "@babel/plugin-transform-react-jsx-development": "^7.12.17",
         "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz",
-          "integrity": "sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==",
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
           "dev": true
         }
       }
@@ -4157,9 +4163,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+      "version": "4.14.169",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.169.tgz",
+      "integrity": "sha512-DvmZHoHTFJ8zhVYwCLWbQ7uAbYQEk52Ev2/ZiQ7Y7gQGeV9pjBqjnQpECMHfKS1rCYAhMI7LHVxwyZLZinJgdw=="
     },
     "@types/loglevel": {
       "version": "1.6.3",
@@ -9211,9 +9217,9 @@
       }
     },
     "marked": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
-      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
       "dev": true
     },
     "mem": {
@@ -11940,9 +11946,9 @@
       }
     },
     "typedoc": {
-      "version": "0.20.32",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.32.tgz",
-      "integrity": "sha512-GSopd/tiqoKE3fEdvhoaEpR9yrEPsR9tknAjkoeSPL6p1Rq5aVsKxBhhF6cwoDJ7oWjpvnm8vs0rQN0BxEHuWQ==",
+      "version": "0.20.36",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.36.tgz",
+      "integrity": "sha512-qFU+DWMV/hifQ9ZAlTjdFO9wbUIHuUBpNXzv68ZyURAP9pInjZiO4+jCPeAzHVcaBCHER9WL/+YzzTt6ZlN/Nw==",
       "dev": true,
       "requires": {
         "colors": "^1.4.0",
@@ -11950,12 +11956,12 @@
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "lunr": "^2.3.9",
-        "marked": "^2.0.1",
+        "marked": "^2.0.3",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",
         "shiki": "^0.9.3",
-        "typedoc-default-themes": "^0.12.9"
+        "typedoc-default-themes": "^0.12.10"
       },
       "dependencies": {
         "fs-extra": {
@@ -11989,9 +11995,9 @@
       }
     },
     "typedoc-default-themes": {
-      "version": "0.12.9",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.9.tgz",
-      "integrity": "sha512-Jd5fYTiqzinZdoIY382W7tQXTwAzWRdg8KbHfaxmb78m1/3jL9riXtk23oBOKwhi8GFVykCOdPzEJKY87/D0LQ==",
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
+      "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
       "dev": true
     },
     "typescript": {
@@ -12001,9 +12007,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.1.tgz",
-      "integrity": "sha512-EWhx3fHy3M9JbaeTnO+rEqzCe1wtyQClv6q3YWq0voOj4E+bMZBErVS1GAHPDiRGONYq34M1/d8KuQMgvi6Gjw==",
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
+      "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA==",
       "dev": true,
       "optional": true
     },
@@ -12225,9 +12231,9 @@
       "dev": true
     },
     "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -12312,9 +12318,9 @@
       }
     },
     "validator": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
-      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "verror": {
       "version": "1.10.0",
@@ -12328,9 +12334,9 @@
       }
     },
     "vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.4.0.tgz",
+      "integrity": "sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==",
       "dev": true
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/terrestris/base-util#readme",
   "dependencies": {
-    "@types/lodash": "^4.14.168",
+    "@types/lodash": "^4.14.169",
     "@types/loglevel": "^1.6.3",
     "@types/url-parse": "^1.4.3",
     "@types/url-search-params": "^1.1.0",
@@ -46,16 +46,16 @@
     "lodash": "^4.17.20",
     "loglevel": "^1.7.1",
     "query-string": "^6.13.8",
-    "url-parse": "^1.4.7",
+    "url-parse": "^1.5.1",
     "url-search-params": "^1.1.0",
-    "validator": "^13.5.2"
+    "validator": "^13.6.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-proposal-function-bind": "^7.12.1",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@babel/preset-env": "^7.12.11",
-    "@babel/preset-react": "^7.12.10",
+    "@babel/preset-react": "^7.13.13",
     "@types/jest": "^26.0.20",
     "coveralls": "^3.1.0",
     "gh-pages": "^3.1.0",
@@ -65,7 +65,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
     "tslint": "^6.1.0",
-    "typedoc": "^0.20.19",
+    "typedoc": "^0.20.36",
     "typescript": "^4.1.3",
     "whatwg-fetch": "^3.5.0"
   },

--- a/src/UrlUtil/UrlUtil.spec.ts
+++ b/src/UrlUtil/UrlUtil.spec.ts
@@ -30,7 +30,7 @@ describe('UrlUtil', () => {
       it('stringifies a given URL object', () => {
         let exp = new URL('http://borussia.de?bvb=true');
         let got = UrlUtil.write(exp);
-        expect(got).toBe('http://borussia.de?bvb=true');
+        expect(got).toBe('http://borussia.de/?bvb=true'); // note the added slash
       });
     });
 
@@ -46,7 +46,7 @@ describe('UrlUtil', () => {
         expect(got).toBe('https://borussia.de/bvb');
 
         got = UrlUtil.getBasePath('https://borussia.de?bvb=09');
-        expect(got).toBe('https://borussia.de');
+        expect(got).toBe('https://borussia.de/');
       });
     });
 
@@ -131,7 +131,7 @@ describe('UrlUtil', () => {
         expect(UrlUtil.createValidGetCapabilitiesRequest).toBeDefined();
       });
       it('returns a valid GetCapabilities request', () => {
-        const validUrl = 'http://borussia.de?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0';
+        const validUrl = 'http://borussia.de/?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0';
 
         let got = UrlUtil.createValidGetCapabilitiesRequest('http://borussia.de');
         expect(got).toEqual(validUrl);
@@ -140,14 +140,14 @@ describe('UrlUtil', () => {
         expect(got).toEqual(validUrl);
 
         got = UrlUtil.createValidGetCapabilitiesRequest('http://borussia.de?VERSION=1.1.0&REQUEST=GetCapabilities');
-        expect(got).toEqual('http://borussia.de?REQUEST=GetCapabilities&VERSION=1.1.0&SERVICE=WMS');
+        expect(got).toEqual('http://borussia.de/?REQUEST=GetCapabilities&VERSION=1.1.0&SERVICE=WMS');
 
         got = UrlUtil.createValidGetCapabilitiesRequest('http://borussia.de?SERVICE=WMS&REQUEST=GetCapabilities',
           null, '1.1.0');
-        expect(got).toEqual('http://borussia.de?REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.1.0');
+        expect(got).toEqual('http://borussia.de/?REQUEST=GetCapabilities&SERVICE=WMS&VERSION=1.1.0');
 
         got = UrlUtil.createValidGetCapabilitiesRequest('http://borussia.de', 'WFS', '1.1.0');
-        expect(got).toEqual('http://borussia.de?SERVICE=WFS&REQUEST=GetCapabilities&VERSION=1.1.0');
+        expect(got).toEqual('http://borussia.de/?SERVICE=WFS&REQUEST=GetCapabilities&VERSION=1.1.0');
       });
     });
 
@@ -160,7 +160,7 @@ describe('UrlUtil', () => {
           'http://maps.bvb.de?SERVICE=WMS&REQUEST=GetFeatureInfo&LAYERS=Shinji',
           'http://maps.bvb.de?SERVICE=WMS&REQUEST=GetFeatureInfo&LAYERS=Kagawa'
         ], true);
-        expect(got).toEqual(['http://maps.bvb.de?LAYERS=Shinji%2CKagawa&REQUEST=GetFeatureInfo&SERVICE=WMS']);
+        expect(got).toEqual(['http://maps.bvb.de/?LAYERS=Shinji%2CKagawa&REQUEST=GetFeatureInfo&SERVICE=WMS']);
 
         got = UrlUtil.bundleOgcRequests([
           'http://maps.bvb.de?LAYERS=Shinji&REQUEST=GetFeatureInfo&SERVICE=WMS',
@@ -168,8 +168,8 @@ describe('UrlUtil', () => {
           'https://maps.bvb.de?LAYERS=Kagawa&REQUEST=GetFeatureInfo&SERVICE=WMS'
         ], true);
         expect(got).toEqual([
-          'http://maps.bvb.de?LAYERS=Shinji%2CKagawa&REQUEST=GetFeatureInfo&SERVICE=WMS',
-          'https://maps.bvb.de?LAYERS=Kagawa&REQUEST=GetFeatureInfo&SERVICE=WMS'
+          'http://maps.bvb.de/?LAYERS=Shinji%2CKagawa&REQUEST=GetFeatureInfo&SERVICE=WMS',
+          'https://maps.bvb.de/?LAYERS=Kagawa&REQUEST=GetFeatureInfo&SERVICE=WMS'
         ]);
 
         got = UrlUtil.bundleOgcRequests([
@@ -178,8 +178,8 @@ describe('UrlUtil', () => {
           'https://maps.bvb.de?SERVICE=WMS&REQUEST=GetFeatureInfo&LAYERS=Kagawa'
         ], true, ['PETER']);
         expect(got).toEqual([
-          'http://maps.bvb.de?LAYERS=Shinji&REQUEST=GetFeatureInfo&SERVICE=WMS',
-          'https://maps.bvb.de?LAYERS=Kagawa&REQUEST=GetFeatureInfo&SERVICE=WMS'
+          'http://maps.bvb.de/?LAYERS=Shinji&REQUEST=GetFeatureInfo&SERVICE=WMS',
+          'https://maps.bvb.de/?LAYERS=Kagawa&REQUEST=GetFeatureInfo&SERVICE=WMS'
         ]);
 
         got = UrlUtil.bundleOgcRequests([
@@ -187,7 +187,7 @@ describe('UrlUtil', () => {
           'http://maps.bvb.de?SERVICE=WMS&REQUEST=GetFeatureInfo&LAYERS=Kagawa'
         ]);
         expect(got).toEqual({
-          'http://maps.bvb.de': {
+          'http://maps.bvb.de/': {
             SERVICE: 'WMS',
             REQUEST: 'GetFeatureInfo',
             LAYERS: 'Shinji,Kagawa'
@@ -199,7 +199,7 @@ describe('UrlUtil', () => {
           'http://maps.bvb.de?SERVICE=WMS&REQUEST=GetFeatureInfo&LAYERS=Kagawa'
         ], false);
         expect(got).toEqual({
-          'http://maps.bvb.de': {
+          'http://maps.bvb.de/': {
             SERVICE: 'WMS',
             REQUEST: 'GetFeatureInfo',
             LAYERS: 'Shinji,Kagawa'


### PR DESCRIPTION
This updates the following (dev-) dependencies:

* `@babel/preset-react` to `v7.13.13`
* `url-parse` to `v1.5.1`
* `@types/lodash` to `v4.14.169`
* `validator` to `v13.6.0`
* `typedoc` to `v0.20.36`

The behaviour of `url-parse` has changed, as you can see in [the changes to the tests](https://github.com/terrestris/base-util/pull/429/commits/4077f447db01684fc79947fea0b20a7aa854f26c). We now always should get back a URL where the `/` comes after the top level domain, e.g. `https://effzeh.com` now would be `https://effzeh.com/`. I do not consider thsi a breaking change, as the contract of the method basically states give me a valid URL, not how exactly it is constructed. I am open to different opinions of course.

Please review.

Closes #420 