### PR TITLE
Add tests for ArrayTwoOrMore

### DIFF
--- a/src/types.spec.ts
+++ b/src/types.spec.ts
@@ -1,0 +1,34 @@
+import { isArrayTwoOrMore } from './types';
+
+describe('isArrayTwoOrMore', () => {
+  it('handles null', () => {
+    const got = isArrayTwoOrMore(null);
+    expect(got).toBe(false);
+  });
+  it('handles array like objects, length=1', () => {
+    // One should not do this, but it is working
+    const got = isArrayTwoOrMore({length: 1} as unknown[]);
+    expect(got).toBe(false);
+  });
+  it('handles array like objects, length>1', () => {
+    // One should not do this, but it is working
+    const got = isArrayTwoOrMore({length: 42} as unknown[]);
+    expect(got).toBe(true);
+  });
+  it('handles empty arrays', () => {
+    const got = isArrayTwoOrMore([]);
+    expect(got).toBe(false);
+  });
+  it('handles arrays with length=1', () => {
+    const got = isArrayTwoOrMore(['one']);
+    expect(got).toBe(false);
+  });
+  it('handles arrays with length>1', () => {
+    const got = isArrayTwoOrMore(['one', 'two']);
+    expect(got).toBe(true);
+  });
+  it('handles arrays with length>1, different type', () => {
+    const got = isArrayTwoOrMore(['one', 2]);
+    expect(got).toBe(true);
+  });
+});


### PR DESCRIPTION
`types.ts` was [untested previously](), this PR suggests to add basic tests for the `isArrayTwoOrMore` function:

```
----------------|---------|----------|---------|---------|-------------------
File            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------|---------|----------|---------|---------|-------------------
All files       |   99.04 |    98.45 |   97.96 |   99.28 |                   
 src            |     100 |      100 |     100 |     100 |                   
  Logger.ts     |     100 |      100 |     100 |     100 |                   
  index.ts      |     100 |      100 |     100 |     100 |                   
  types.ts      |     100 |      100 |     100 |     100 |                   
 src/CsrfUtil   |     100 |    92.86 |     100 |     100 |                   
  CsrfUtil.ts   |     100 |    92.86 |     100 |     100 | 72                
 src/HttpUtil   |   91.43 |      100 |      75 |   92.59 |                   
  HttpUtil.ts   |   91.43 |      100 |      75 |   92.59 | 66,79             
 src/MathUtil   |     100 |      100 |     100 |     100 |                   
  MathUtil.ts   |     100 |      100 |     100 |     100 |                   
 src/ObjectUtil |     100 |    97.06 |     100 |     100 |                   
  ObjectUtil.ts |     100 |    97.06 |     100 |     100 | 107               
 src/StringUtil |     100 |      100 |     100 |     100 |                   
  StringUtil.ts |     100 |      100 |     100 |     100 |                   
 src/UndoUtil   |     100 |      100 |     100 |     100 |                   
  UndoUtil.ts   |     100 |      100 |     100 |     100 |                   
 src/UrlUtil    |     100 |      100 |     100 |     100 |                   
  UrlUtil.ts    |     100 |      100 |     100 |     100 |                   
----------------|---------|----------|---------|---------|-------------------

```

Please review.