### PR TITLE
Fix badges in the README

### DIFF
--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -1,4 +1,4 @@
-name: Run coveralls
+name: Test including coverage
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # base-util
 
-[![Dependabot badge](https://api.dependabot.com/badges/status?host=github&repo=terrestris/base-util)](https://dependabot.com/)
-[![Build Status](https://travis-ci.org/terrestris/base-util.svg?branch=master)](https://travis-ci.org/terrestris/base-util)
+[![npm version](https://img.shields.io/npm/v/@terrestris/base-util.svg?style=flat-square)](https://www.npmjs.com/package/@terrestris/base-util)
+[![GitHub license](https://img.shields.io/github/license/terrestris/base-util?style=flat-square)](https://github.com/terrestris/base-util/blob/master/LICENSE)
+[![CI](https://github.com/terrestris/base-util/actions/workflows/on-push-master.yml/badge.svg)](https://github.com/terrestris/base-util/actions/workflows/on-push-master.yml)
 [![Coverage Status](https://coveralls.io/repos/github/terrestris/base-util/badge.svg?branch=master)](https://coveralls.io/github/terrestris/base-util?branch=master)
 
 A set of helper classes for working with strings, objects, etc.


### PR DESCRIPTION
…also give the on-push-master workflow a more meaningful name.

Current state

![image](https://github.com/terrestris/base-util/assets/227934/efdc63aa-b1cf-4934-884c-cbaaa4d5b42a)

New state (please ignore the black background, the unrecognizable license and the ill-named workflow name)

![image](https://github.com/terrestris/base-util/assets/227934/1e6575fc-e800-42bb-8b9b-c697ec50406b)


This should give us back shiny badges again.

