### PR TITLE
Don't quote property 'metaTagName' to remove lint warning

### DIFF
--- a/src/CsrfUtil/CsrfUtil.spec.ts
+++ b/src/CsrfUtil/CsrfUtil.spec.ts
@@ -59,7 +59,7 @@ describe('CsrfUtil', () => {
       // remove custom CSRF headers
       specs.forEach((spec) => {
         let compiledSelector = template('meta[name="<%= metaTagName %>"]');
-        let element = document.querySelector(compiledSelector({ 'metaTagName': spec.name }));
+        let element = document.querySelector(compiledSelector({ metaTagName: spec.name }));
         element.parentNode.removeChild(element);
       });
     });

--- a/src/CsrfUtil/CsrfUtil.ts
+++ b/src/CsrfUtil/CsrfUtil.ts
@@ -27,14 +27,14 @@ class CsrfUtil {
    */
   static getContentFromMetaTagByName(name: string) {
     const compiledSelector = template('meta[name="<%= metaTagName %>"]');
-    const element: Element = document.querySelector(compiledSelector({ 'metaTagName': name }));
+    const element: Element = document.querySelector(compiledSelector({ metaTagName: name }));
     let content;
     if (element) {
       content = element.getAttribute('content') || '';
     } else {
       let warnTpl = template('Failed to find tag <meta name=<%= metaTagName %> />. Is it ' +
           ' present in the page DOM?');
-      Logger.warn(warnTpl({ 'metaTagName': name }));
+      Logger.warn(warnTpl({ metaTagName: name }));
       content = '';
     }
     return content;


### PR DESCRIPTION
This removes the following linter warnings:

```
/home/mj/code/base-util/src/CsrfUtil/CsrfUtil.spec.ts
  62:65  warning  Unnecessarily quoted property 'metaTagName' found  quote-props

/home/mj/code/base-util/src/CsrfUtil/CsrfUtil.ts
  30:72  warning  Unnecessarily quoted property 'metaTagName' found  quote-props
  37:29  warning  Unnecessarily quoted property 'metaTagName' found  quote-props

✖ 3 problems (0 errors, 3 warnings)
  0 errors and 3 warnings potentially fixable with the `--fix` option.

```

Please review.