### PR TITLE
fix: use correct module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@terrestris/base-util",
   "version": "1.1.0",
   "description": "A set of helper classes for working with strings, objects, etc.",
-  "module": "src/index.js",
+  "module": "src/index.ts",
   "main": "dist/index.js",
   "browser": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
The module property was pointing to a non-existant file in the distribution. This is causing problems with vite setups.